### PR TITLE
Replaced lastIndexOf(string) call with the faster lastIndexOf(char)

### DIFF
--- a/simple/src/main/java/org/apache/commons/rdf/simple/experimental/AbstractRDFParser.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/experimental/AbstractRDFParser.java
@@ -507,7 +507,7 @@ public abstract class AbstractRDFParser<T extends AbstractRDFParser<T>> implemen
             return Optional.empty();
         }
         final String filenameStr = fileName.toString();
-        final int last = filenameStr.lastIndexOf(".");
+        final int last = filenameStr.lastIndexOf('.');
         if (last > -1) {
             return Optional.of(filenameStr.substring(last));
         }


### PR DESCRIPTION
Lecseréltem a kérdéses hívást char megfelelőre, SonarQube szerint eltűnt a hiba, szóval elvileg jónak kellene lennie.