### PR TITLE
Javadoc

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/RDFSyntax.java
@@ -129,7 +129,7 @@ public interface RDFSyntax {
     public String getmediaType();
 
     /**
-     * Set of <a href="https://tools.ietf.org/html/rfc2046">IANA media types/a> that
+     * Set of <a href="https://tools.ietf.org/html/rfc2046">IANA media types</a> that
      * covers this RDF syntax, including any non-official media types. 
      * <p>
      * The media type can be used as part of <code>Content-Type</code> and
@@ -236,7 +236,7 @@ public interface RDFSyntax {
      * <p>
      * The <code>mediaType</code> is compared in lower case to all media types
      * supported, therefore it might not be equal to the
-     * {@link RDFSyntax#mediaType} of the returned RDFSyntax.
+     * {@link RDFSyntax#getmediaType()} of the returned RDFSyntax.
      * <p>
      * If the media type specifies parameters, e.g.
      * <code>text/turtle; charset=ascii</code>, only the part of the string to
@@ -262,7 +262,7 @@ public interface RDFSyntax {
      * <p>
      * The <code>fileExtension</code> is compared in lower case to all
      * extensions supported, therefore it might not be equal to the
-     * {@link RDFSyntax#fileExtension} of the returned RDFSyntax.
+     * {@link RDFSyntax#getfileExtension()} of the returned RDFSyntax.
      * <p>
      * This method support all syntaxes returned by {@link #w3cSyntaxes()}.
      * 

--- a/jena/src/main/java/org/apache/commons/rdf/jena/JenaRDF.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/JenaRDF.java
@@ -244,7 +244,6 @@ public final class JenaRDF implements RDF {
      *            The Jena Node to adapt. It's {@link Node#isConcrete()} must be
      *            <code>true</code>.
      * @return Adapted {@link JenaRDFTerm}
-     * @
      *             If the {@link Node} can't be represented as an
      *             {@link RDFTerm}, e.g. if the node is not concrete or
      *             represents a variable in Jena.
@@ -269,7 +268,6 @@ public final class JenaRDF implements RDF {
      *            The Jena Node to adapt. It's {@link Node#isConcrete()} must be
      *            <code>true</code>.
      * @return Adapted {@link RDFTerm}
-     * @
      *             If the {@link Node} can't be represented as an
      *             {@link RDFTerm}, e.g. if the node is not concrete or
      *             represents a variable in Jena.
@@ -316,7 +314,6 @@ public final class JenaRDF implements RDF {
      * @param triple
      *            Jena {@link org.apache.jena.graph.Triple} to adapt
      * @return Adapted {@link JenaTriple}
-     * @
      *             if any of the triple's nodes are not concrete or the triple
      *             is a generalized triple
      */
@@ -345,7 +342,6 @@ public final class JenaRDF implements RDF {
      * @return Adapted {@link TripleLike}. Note that the generalized triple does
      *         <strong>not</strong> implement {@link Triple#equals(Object)} or
      *         {@link Triple#hashCode()}.
-     * @
      *             if any of the triple's nodes are not concrete
      */
     public JenaTripleLike asGeneralizedTriple(final org.apache.jena.graph.Triple triple) {
@@ -378,7 +374,6 @@ public final class JenaRDF implements RDF {
      * @return Adapted {@link QuadLike}. Note that the generalized quad does
      *         <strong>not</strong> implement {@link Quad#equals(Object)} or
      *         {@link Quad#hashCode()}.
-     * @
      *             if any of the quad nodes are not concrete
      */
     public JenaQuadLike<RDFTerm> asGeneralizedQuad(final org.apache.jena.sparql.core.Quad quad) {
@@ -402,7 +397,6 @@ public final class JenaRDF implements RDF {
      * @param triple
      *            Jena triple
      * @return Converted triple
-     * @
      *             if any of the triple's nodes are not concrete or the triple
      *             is a generalized triple
      */
@@ -552,7 +546,6 @@ public final class JenaRDF implements RDF {
      * @param quad
      *            Jena {@link org.apache.jena.sparql.core.Quad} to adapt
      * @return Converted {@link Quad}
-     * @
      *             if any of the quad's nodes are not concrete or the quad is a
      *             generalized quad
      */

--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,9 @@
             <!-- japicmp requires "mvn package site" - below means "mvn
              site" still works (but without japicmp report) -->
         <ignoreMissingNewVersion>true</ignoreMissingNewVersion>
+            <excludes>
+                <exclude>org.apache.commons.rdf.api.RDFSyntax</exclude>
+            </excludes>
           </parameter>
         </configuration>
           </plugin>

--- a/simple/src/main/java/org/apache/commons/rdf/simple/experimental/AbstractRDFParser.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/experimental/AbstractRDFParser.java
@@ -89,7 +89,7 @@ public abstract class AbstractRDFParser<T extends AbstractRDFParser<T>> implemen
 	 * Get the set content-type {@link RDFSyntax}, if any.
 	 * <p>
 	 * If this is {@link Optional#isPresent()}, then {@link #getContentType()}
-	 * contains the value of {@link RDFSyntax#mediaType}.
+	 * contains the value of {@link RDFSyntax#getmediaType()}.
 	 * 
 	 * @return The {@link RDFSyntax} of the content type, or
 	 *         {@link Optional#empty()} if it has not been set
@@ -480,7 +480,7 @@ public abstract class AbstractRDFParser<T extends AbstractRDFParser<T>> implemen
 	 * @param path
 	 *            Path which extension should be checked
 	 * @return The {@link RDFSyntax} which has a matching
-	 *         {@link RDFSyntax#fileExtension}, otherwise
+	 *         {@link RDFSyntax#getfileExtension()}, otherwise
 	 *         {@link Optional#empty()}.
 	 */
 	protected static Optional<RDFSyntax> guessRDFSyntax(final Path path) {


### PR DESCRIPTION
javadoc hibak kijavitasa, amelyek miatt nem mukodik a mvn build.
tovabba japicmp exclude hozzaadasa a pom fajlhoz.